### PR TITLE
feat: server v0.2

### DIFF
--- a/bruno/exporter-server/export-orders.bru
+++ b/bruno/exporter-server/export-orders.bru
@@ -1,0 +1,24 @@
+meta {
+  name: export-orders
+  type: http
+  seq: 5
+}
+
+post {
+  url: http://localhost:3000/orders
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+  User-Agent: {{useragent}}
+}
+
+body:json {
+  {
+    "lastOrderID": "192531131044199",
+    "offSetID": ""
+  }
+}

--- a/packages/exporter/export.ts
+++ b/packages/exporter/export.ts
@@ -10,9 +10,8 @@ export async function exportNewData(
 	const orders: ExtractedOrder[] = await exportData(cookies, userAgent, offSetID);
 
 	if (lastOrderID) {
-		const targetIndex = orders.findIndex((item: ExtractedOrder) => item.order_id === lastOrderID);
-
-		if (targetIndex) {
+		const targetIndex = orders.findIndex((item: ExtractedOrder) => item.order_id.toString() === lastOrderID);
+		if (targetIndex >= 0) {
 			const precedingItems = orders.slice(0, targetIndex);
 			return precedingItems;
 		}

--- a/packages/exporter/index.ts
+++ b/packages/exporter/index.ts
@@ -1,1 +1,2 @@
 export { visitSwiggy, generateOTP, performLogin } from './login';
+export { exportNewData } from './export';

--- a/packages/exporter/package.json
+++ b/packages/exporter/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "exporter",
 	"module": "index.ts",
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"type": "module",
 	"devDependencies": {
 		"@types/bun": "latest"

--- a/packages/exporter/package.json
+++ b/packages/exporter/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "exporter",
 	"module": "index.ts",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"type": "module",
 	"devDependencies": {
 		"@types/bun": "latest"

--- a/packages/exporter/utils.ts
+++ b/packages/exporter/utils.ts
@@ -11,13 +11,13 @@ export const constOpts: RequestInit = {
 
 export async function hitURL(url: string, options: RequestInit) {
 	console.log('Request Hit url: ', url);
-	console.log('Request headers: ', options.headers);
-	console.log('Request payload: ', options.body);
+	// console.log('Request headers: ', options.headers);
+	// console.log('Request payload: ', options.body);
 
 	const response = await fetch(url, options);
 
 	console.log('Response status:  ', response.status, response.statusText);
-	console.log('Response headers: ', response.headers);
+	// console.log('Response headers: ', response.headers);
 
 	if (!response.ok) {
 		const message = `An error has occured: ${response.status} , ${response.statusText}`;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "server",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"scripts": {
 		"dev": "bun run --hot src/index.ts"
 	},

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -46,7 +46,8 @@ app.post('/login/auth', async (c) => {
 	if (!requestCookies || !csrf) {
 		throw new SwiggyError('csrf or requestCookies are invalid', 400);
 	} else {
-		requestCookies = await exporter.performLogin(ua, body.ss, requestCookies, csrf);
+		requestCookies = await exporter.performLogin(ua, body.otp, requestCookies, csrf);
+		setCookie(c, 'request-cookies', requestCookies, { path: '/', httpOnly: true });
 		return c.json(
 			{ status: 'Success', code: 0, message: 'Logged in Sucessfully', data: { csrf, requestCookies } },
 			200

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -55,6 +55,20 @@ app.post('/login/auth', async (c) => {
 	}
 });
 
+app.post('/orders', async (c) => {
+	const ua = c.req.header('User-Agent') ?? '';
+	const { lastOrderID, offSetID } = await c.req.json();
+
+	let requestCookies = getCookie(c, 'request-cookies');
+
+	if (!requestCookies) {
+		throw new SwiggyError('requestCookies are invalid', 400);
+	}
+	const data = await exporter.exportNewData(lastOrderID, requestCookies, ua, offSetID);
+
+	return c.json({ status: 'Success', code: 0, message: 'Fetched Orders Sucessfully', data: data }, 200);
+});
+
 app.onError((err, c) => {
 	if (err instanceof SwiggyError) {
 		return c.json(


### PR DESCRIPTION
This PR:

- Fixes #16 
- Fixes `/login/auth` endpoint
- Adds `/orders` endpoint in `server`
- Bumps server version to `0.2.0` and `exporter to `0.4.0`

I need to decide when I can have versions `1.0` for both.