### PR TITLE
Server/refactor 01

### DIFF
--- a/packages/server/public/openapi.json
+++ b/packages/server/public/openapi.json
@@ -233,7 +233,9 @@
 					"status": { "type": "string", "example": "Failure" },
 					"error": { "type": "string" },
 					"code": { "type": "integer", "example": -1 },
-					"cause": { "type": "string" }
+					"cause": { "type": "string" },
+					"txnID": { "type": "string" },
+					"sessionID": { "type": "string" }
 				}
 			},
 			"SwiggySuccessResponse": {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -78,6 +78,7 @@ app.post('/orders', async (c) => {
 });
 
 app.onError((err, c) => {
+	console.error(`[Error] ${err.message}`);
 	if (err instanceof SwiggyError) {
 		return c.json(
 			{
@@ -85,6 +86,8 @@ app.onError((err, c) => {
 				error: err.message,
 				code: err.statusCode,
 				cause: err.reason || null,
+				txnID: c.req.header('X-Txn-ID') || null,
+				sessionID: getCookie(c, 'sessionID') || null,
 			},
 			err.statusCode === 400 ? 400 : 500
 		);
@@ -97,6 +100,8 @@ app.onError((err, c) => {
 			error: err.message,
 			code: 500,
 			cause: err?.cause || null,
+			txnID: c.req.header('X-Txn-ID') || null,
+			sessionID: getCookie(c, 'sessionID') || null,
 		},
 		500
 	);

--- a/packages/server/src/routes/login.ts
+++ b/packages/server/src/routes/login.ts
@@ -1,0 +1,58 @@
+import SwiggyError from 'exporter/SwiggyError';
+import { Hono } from 'hono';
+import { getCookie, setCookie } from 'hono/cookie';
+import * as exporter from 'exporter';
+
+const loginRoutes = new Hono();
+
+// Grab CSRF token and cookies for subsequent requests.
+loginRoutes.get('/', async (c) => {
+	const ua = c.req.header('User-Agent') ?? '';
+
+	const data = await exporter.visitSwiggy(ua);
+	if (Object.keys(data).length) {
+		setCookie(c, 'request-cookies', data.requestCookies, { path: '/', httpOnly: true });
+		setCookie(c, 'request-csrf', data.csrf, { path: '/login', httpOnly: true });
+		return c.json({ status: 'Success', code: 0, message: 'Acquired CSRF token', data: data }, 200);
+	}
+	return c.json('Failed to get CSRF token from swiggy.com', 500);
+});
+
+// Generate otp
+loginRoutes.post('/otp', async (c) => {
+	const ua = c.req.header('User-Agent') ?? '';
+	const body = await c.req.json();
+	const csrf = getCookie(c, 'request-csrf');
+	const requestCookies = getCookie(c, 'request-cookies');
+
+	if (!requestCookies || !csrf) {
+		throw new SwiggyError('csrf or requestCookies are invalid', 400);
+	} else {
+		await exporter.generateOTP(ua, body.mobileNumber, requestCookies, csrf);
+		return c.json(
+			{ status: 'Success', code: 0, message: 'Generated OTP Successfully', data: { csrf, requestCookies } },
+			200
+		);
+	}
+});
+
+// Login user
+loginRoutes.post('/auth', async (c) => {
+	const ua = c.req.header('User-Agent') ?? '';
+	const body = await c.req.json();
+	const csrf = getCookie(c, 'request-csrf');
+	let requestCookies = getCookie(c, 'request-cookies');
+
+	if (!requestCookies || !csrf) {
+		throw new SwiggyError('csrf or requestCookies are invalid', 400);
+	} else {
+		requestCookies = await exporter.performLogin(ua, body.otp, requestCookies, csrf);
+		setCookie(c, 'request-cookies', requestCookies, { path: '/', httpOnly: true });
+		return c.json(
+			{ status: 'Success', code: 0, message: 'Logged in Sucessfully', data: { csrf, requestCookies } },
+			200
+		);
+	}
+});
+
+export default loginRoutes;

--- a/packages/server/src/routes/swiggy-orders.ts
+++ b/packages/server/src/routes/swiggy-orders.ts
@@ -1,0 +1,22 @@
+import SwiggyError from 'exporter/SwiggyError';
+import { Hono } from 'hono';
+import { getCookie } from 'hono/cookie';
+import * as exporter from 'exporter';
+
+const orderRoutes = new Hono();
+
+orderRoutes.post('/', async (c) => {
+	const ua = c.req.header('User-Agent') ?? '';
+	const { lastOrderID, offSetID } = await c.req.json();
+
+	let requestCookies = getCookie(c, 'request-cookies');
+
+	if (!requestCookies) {
+		throw new SwiggyError('requestCookies are invalid', 400);
+	}
+	const data = await exporter.exportNewData(lastOrderID, requestCookies, ua, offSetID);
+
+	return c.json({ status: 'Success', code: 0, message: 'Fetched Orders Sucessfully', data: data }, 200);
+});
+
+export default orderRoutes;


### PR DESCRIPTION
This PR:

- Moves `/login` related routes to `login.ts`
- Moves `/order` related routes to `swiggy-order.ts`
- Adds a `/health` endpoint to check uptime
- Adds `txnID` and `sessionID` to better correlate errors. This will be generated from client and sent.
- Changes default port to `4321`
